### PR TITLE
Merge to test whether GHA can only be triggered from `main` branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 inst/doc
 **/*.Rd
 docs
+


### PR DESCRIPTION
The `main` branch has been edited to remove all the **pkgdown** stuff, so the website cannot be built from there. I just confirmed that the GHA workflow to build the website is not triggered by pushing to the `dev` branch, which still has all the **pkgdown** infrastructure. Now merge `dev` into `main` to test whether GHA will run.